### PR TITLE
feat(parser): establish plain text field format with bidirectional co…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,30 +78,37 @@ project-root/
 
 ### PuyoP.com Parser
 
-- `src/tools/puyop-parser.js` - Parses puyop.com simulator URLs and converts
-  field data to plain text
-- `src/tools/puyop-parser.test.js` - Test script for the parser functionality
+- `src/tools/puyop-parser.js` - Bidirectional converter between puyop.com URLs and plain text field format
+- `src/tools/puyop-parser.test.js` - Comprehensive test script with bidirectional conversion tests
 - `src/tools/run-tests.sh` - Test runner script
+- `doc/plain-text-field-format.md` - Complete specification for plain text field format
 
 **Usage:**
 
 ```bash
-# Run the parser directly
-deno run --allow-net src/tools/puyop-parser.js "https://www.puyop.com/s/?_=000"
+# Convert puyop.com URL to plain text
+deno run --allow-net src/tools/puyop-parser.js "https://www.puyop.com/s/1"
 
-# Run tests
+# Convert plain text to puyop.com URL
+deno run --allow-net src/tools/puyop-parser.js --to-url "RG\nRB"
+
+# Run comprehensive tests (including bidirectional conversion)
 deno run --allow-net src/tools/puyop-parser.test.js
+
+# Run with verbose output
+deno run --allow-net src/tools/puyop-parser.test.js --verbose
 
 # Or use test runner
 ./src/tools/run-tests.sh
 
 # Make executable and run (optional)
 chmod +x src/tools/puyop-parser.js
-./src/tools/puyop-parser.js "https://www.puyop.com/s/?_=000"
+./src/tools/puyop-parser.js "https://www.puyop.com/s/1"
 ```
 
-The parser converts encoded field data into plain text format using these
-symbols:
+**Plain Text Field Format:**
+
+The parser supports a comprehensive plain text format for representing Puyo Puyo fields:
 
 - `.` = Empty cell
 - `R` = Red puyo
@@ -110,6 +117,34 @@ symbols:
 - `Y` = Yellow puyo
 - `P` = Purple puyo
 - `O` = Ojama (garbage)
+- `T` = Iron puyo (Tetsugami)
+- `#` = Comment line
+
+**Features:**
+- **Bidirectional conversion**: Plain text ↔ puyop.com URLs
+- **Comment support**: Lines starting with `#` are ignored
+- **Flexible formatting**: Trailing empty cells and leading empty rows can be omitted
+- **Error handling**: Comprehensive validation and error reporting
+- **Test coverage**: Includes round-trip conversion tests to ensure data integrity
+
+**Examples:**
+
+```bash
+# GTR setup example
+echo "BO.TP.
+BGRYBP  
+BBGRYY
+GGRRYP" | deno run --allow-net src/tools/puyop-parser.js --to-url
+
+# With comments
+echo "# This is a GTR setup
+BO.TP.  # Top row
+BGRYBP  # Second row  
+BBGRYY  # Third row
+GGRRYP  # Bottom row" | deno run --allow-net src/tools/puyop-parser.js --to-url
+```
+
+See `doc/plain-text-field-format.md` for complete format specification and examples.
 
 ## Development Workflow
 

--- a/doc/plain-text-field-format.md
+++ b/doc/plain-text-field-format.md
@@ -1,0 +1,190 @@
+# Plain Text Field Format Specification
+
+## Overview
+
+This document defines the specification for representing Puyo Puyo game fields in plain text format. This format is designed to be human-readable, easily parseable, and compatible with bidirectional conversion to/from puyop.com URLs.
+
+## Field Dimensions
+
+- **Width**: 6 columns (standard Puyo Puyo field width)
+- **Height**: 13 rows (standard Puyo Puyo field height including invisible top row)
+- **Coordinate System**: Row 0 is at the top, Column 0 is at the left
+- **Field Layout**: `field[row][column]` where `row` ranges from 0-12 and `column` ranges from 0-5
+
+## Character Symbols
+
+| Symbol | Meaning | Description |
+|--------|---------|-------------|
+| `.` | Empty | Empty cell (no puyo) |
+| `R` | Red | Red puyo |
+| `G` | Green | Green puyo |
+| `B` | Blue | Blue puyo |
+| `Y` | Yellow | Yellow puyo |
+| `P` | Purple | Purple puyo |
+| `O` | Ojama | Ojama (garbage) puyo |
+| `T` | Iron | Iron puyo (falls but cannot be cleared) |
+| `#` | Comment | Comment line (entire line is ignored) |
+
+## Format Rules
+
+### Basic Structure
+
+```
+# Comment line (optional)
+......  # Row 0 (top, usually invisible)
+......  # Row 1
+......  # Row 2
+......  # Row 3
+......  # Row 4
+......  # Row 5
+......  # Row 6
+......  # Row 7
+......  # Row 8
+......  # Row 9
+......  # Row 10
+......  # Row 11
+RRGGBB  # Row 12 (bottom)
+```
+
+### Trailing Space Omission
+
+- Trailing empty cells (`.`) at the end of each row MAY be omitted
+- If omitted, missing positions are treated as empty (`.`)
+- Example: `RRG` is equivalent to `RRG...`
+
+### Leading Row Omission
+
+- Empty rows at the top of the field MAY be omitted
+- Missing rows are treated as completely empty
+- Example: A field with only bottom 3 rows populated can be written as:
+  ```
+  RG....
+  RRGGBB
+  YYPPOO
+  ```
+  Instead of the full 13-row representation
+
+### Comment Lines
+
+- Lines starting with `#` are treated as comments and ignored during parsing
+- Comments can be placed anywhere in the field representation
+- Inline comments (after field data) are NOT supported
+
+### Whitespace Handling
+
+- Leading and trailing whitespace on each line is ignored
+- Empty lines are ignored
+- Spaces within the field data are NOT allowed (except for trailing spaces which are treated as empty cells)
+
+## Examples
+
+### Example 1: GTR Setup
+```
+# GTR (Green-T-Red) setup example
+BO.TP.
+BGRYBP
+BBGRYY
+GGRRYP
+```
+
+### Example 2: Full Field Representation
+```
+# Complete 13-row field with mixed content
+......
+......
+......
+......
+......
+......
+......
+......
+......
+R.G.B.
+RRGGBB
+YYPPOO
+TTTTTT
+```
+
+### Example 3: Minimal Representation
+```
+# Same field with omitted empty rows and trailing spaces
+R.G.B
+RRGGBB
+YYPPOO
+TTTTTT
+```
+
+### Example 4: Single Puyo
+```
+# Single red puyo at bottom-right
+.....R
+```
+
+### Example 5: With Comments
+```
+# This is a chain setup
+# Red and Blue form a vertical pair
+......
+......
+......
+......
+......
+......
+......
+......
+......
+......
+.....R  # Red puyo
+.....B  # Blue puyo below
+RRGGBB  # Bottom row foundation
+```
+
+## Parsing Algorithm
+
+### From Plain Text to Internal Representation
+
+1. Remove all comment lines (lines starting with `#`)
+2. Remove leading and trailing whitespace from each line
+3. Remove empty lines
+4. Create a 13x6 field initialized with empty cells (`.`)
+5. For each remaining line:
+   - Pad with empty cells (`.`) to reach width of 6 if shorter
+   - Truncate to width of 6 if longer
+   - Map each character to the corresponding cell value
+6. If fewer than 13 rows are provided, assume missing top rows are empty
+
+### From Internal Representation to Plain Text
+
+1. Convert internal field representation to character symbols
+2. Optionally omit trailing empty cells in each row
+3. Optionally omit leading empty rows
+4. Add comments as needed for clarity
+
+## Validation Rules
+
+### Required Validations
+
+- Field width must not exceed 6 columns per row
+- Only valid symbols (`R`, `G`, `B`, `Y`, `P`, `O`, `T`, `.`) are allowed
+- Comment lines must start with `#`
+
+### Recommended Validations
+
+- Warn if field height exceeds 13 rows
+- Warn if invalid characters are encountered
+- Validate that the field represents a physically possible game state
+
+## Bidirectional Conversion Compatibility
+
+This format is designed to be fully compatible with puyop.com URL encoding:
+
+- **To puyop.com**: Plain text → Internal representation → Base62 encoding → URL
+- **From puyop.com**: URL → Base62 decoding → Internal representation → Plain text
+
+The conversion maintains field state exactly, ensuring no data loss in either direction.
+
+## File Extension
+
+When saving plain text field files, the recommended extension is `.puyo` or `.txt`.
+
+Example filename: `gtr-setup.puyo`

--- a/src/tools/puyop-parser.test.js
+++ b/src/tools/puyop-parser.test.js
@@ -1,9 +1,6 @@
 #!/usr/bin/env deno run --allow-net
 
-import {
-  parsePuyopUrl,
-  plainTextToPuyopUrl,
-} from './puyop-parser.js';
+import { parsePuyopUrl, plainTextToPuyopUrl } from './puyop-parser.js';
 
 // Check for verbose flag
 const args = Deno.args;

--- a/src/tools/puyop-parser.test.js
+++ b/src/tools/puyop-parser.test.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env deno run --allow-net
 
-import { parsePuyopUrl } from './puyop-parser.js';
+import {
+  parsePuyopUrl,
+  plainTextToPuyopUrl,
+} from './puyop-parser.js';
 
 // Check for verbose flag
 const args = Deno.args;
@@ -275,7 +278,153 @@ if (failedTests.length > 0) {
   });
 }
 
-// Exit with non-zero code if tests failed
-if (failedTests.length > 0) {
+// Bidirectional conversion tests
+if (verbose) {
+  console.log('\n=== Bidirectional Conversion Tests ===');
+}
+
+const bidirectionalTests = [
+  {
+    name: 'Single red puyo',
+    plainText: '.....R',
+    expectedUrl: 'https://www.puyop.com/s/1',
+  },
+  {
+    name: 'Horizontal pair RR',
+    plainText: '....RR',
+    expectedUrl: 'https://www.puyop.com/s/9',
+  },
+  {
+    name: 'GTR setup',
+    plainText: `BO.TP.
+BGRYBP
+BBGRYY
+GGRRYP`,
+    expectedUrl: null, // We'll generate and verify round-trip
+  },
+  {
+    name: 'Complex field with comments',
+    plainText: `# This is a test field
+R.G.B.
+RRGGBB
+# Bottom row
+YYPPOO`,
+    expectedUrl: null,
+  },
+];
+
+let bidirectionalPassed = 0;
+const bidirectionalFailed = [];
+
+bidirectionalTests.forEach((test, index) => {
+  if (verbose) {
+    console.log(`\nBidirectional Test ${index + 1}: ${test.name}`);
+    console.log('Plain text input:');
+    console.log(test.plainText);
+  }
+
+  try {
+    // Test plain text to URL conversion
+    const generatedUrl = plainTextToPuyopUrl(test.plainText);
+    if (verbose) {
+      console.log(`Generated URL: ${generatedUrl}`);
+    }
+
+    // Test URL back to plain text conversion
+    const roundTripPlainText = parsePuyopUrl(generatedUrl);
+    if (verbose) {
+      console.log('Round-trip plain text:');
+      console.log(roundTripPlainText);
+    }
+
+    // Normalize both texts for comparison (remove comments, empty lines, and leading empty rows)
+    const normalizeText = (text) => {
+      const lines = text.split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0 && !line.startsWith('#'));
+
+      // Remove leading empty rows (lines with only dots)
+      while (lines.length > 0 && lines[0].match(/^\.+$/)) {
+        lines.shift();
+      }
+
+      return lines.join('\n');
+    };
+
+    const originalNormalized = normalizeText(test.plainText);
+    const roundTripNormalized = normalizeText(roundTripPlainText);
+
+    // Check if specific URL is expected
+    if (test.expectedUrl) {
+      if (generatedUrl === test.expectedUrl) {
+        if (verbose) {
+          console.log('✅ URL generation matches expected');
+        }
+      } else {
+        if (verbose) {
+          console.log(
+            `❌ URL mismatch. Expected: ${test.expectedUrl}, Got: ${generatedUrl}`,
+          );
+        }
+        bidirectionalFailed.push({
+          test: test.name,
+          error:
+            `URL mismatch. Expected: ${test.expectedUrl}, Got: ${generatedUrl}`,
+        });
+        return;
+      }
+    }
+
+    // Check round-trip conversion
+    if (originalNormalized === roundTripNormalized) {
+      if (verbose) {
+        console.log('✅ Round-trip conversion successful');
+      }
+      bidirectionalPassed++;
+    } else {
+      if (verbose) {
+        console.log('❌ Round-trip conversion failed');
+        console.log('Original normalized:');
+        console.log(originalNormalized);
+        console.log('Round-trip normalized:');
+        console.log(roundTripNormalized);
+      }
+      bidirectionalFailed.push({
+        test: test.name,
+        error: 'Round-trip conversion failed',
+        original: originalNormalized,
+        roundTrip: roundTripNormalized,
+      });
+    }
+  } catch (error) {
+    if (verbose) {
+      console.log(`❌ Error: ${error.message}`);
+    }
+    bidirectionalFailed.push({
+      test: test.name,
+      error: error.message,
+    });
+  }
+});
+
+console.log(
+  `\nBidirectional Test Summary: ${bidirectionalPassed}/${bidirectionalTests.length} tests passed`,
+);
+
+if (bidirectionalFailed.length > 0) {
+  console.log(
+    `\n❌ ${bidirectionalFailed.length} bidirectional test(s) failed:`,
+  );
+  bidirectionalFailed.forEach((failure) => {
+    console.log(`\n${failure.test}: ${failure.error}`);
+    if (failure.original && failure.roundTrip) {
+      console.log(`Original: ${failure.original}`);
+      console.log(`Round-trip: ${failure.roundTrip}`);
+    }
+  });
+}
+
+// Exit with non-zero code if any tests failed
+if (failedTests.length > 0 || bidirectionalFailed.length > 0) {
   Deno.exit(1);
 }


### PR DESCRIPTION
…nversion (#7)

- Add comprehensive plain text field format specification
- Extend puyop-parser with bidirectional URL ↔ plain text conversion
- Support comment lines (#), flexible formatting, and Iron puyo (T)
- Add comprehensive bidirectional conversion tests with round-trip validation
- Update documentation with new capabilities and usage examples
- Maintain backward compatibility with existing URL parsing

Resolves #7

🤖 Generated with [Claude Code](https://claude.ai/code)