### PR TITLE
Add Rust simulation crate skeleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["puyosim-core"]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ deno coverage coverage --lcov --output=coverage.lcov
 ```
 ├── .github/workflows/     # GitHub Actions workflows
 ├── doc/                   # Documentation and guides
-├── src/tools/            # Development tools and utilities
+├── puyosim-core/          # Rust simulation library
+├── src/tools/             # Development tools and utilities
 ├── deno.json             # Deno configuration
 ├── CLAUDE.md             # Development guidance for Claude Code
 └── README.md

--- a/puyosim-core/Cargo.toml
+++ b/puyosim-core/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "puyosim-core"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+description = "Core library for simulating Puyo Puyo fields"
+
+[dependencies]

--- a/puyosim-core/src/field.rs
+++ b/puyosim-core/src/field.rs
@@ -1,0 +1,37 @@
+use crate::puyo::Puyo;
+
+#[derive(Clone, Debug)]
+pub struct Field {
+    pub width: usize,
+    pub height: usize,
+    cells: Vec<Option<Puyo>>, 
+}
+
+impl Field {
+    pub fn new(width: usize, height: usize) -> Self {
+        Self {
+            width,
+            height,
+            cells: vec![None; width * height],
+        }
+    }
+
+    pub fn index(&self, x: usize, y: usize) -> usize {
+        y * self.width + x
+    }
+
+    pub fn get(&self, x: usize, y: usize) -> Option<Puyo> {
+        self.cells[self.index(x, y)]
+    }
+
+    pub fn set(&mut self, x: usize, y: usize, puyo: Option<Puyo>) {
+        let idx = self.index(x, y);
+        self.cells[idx] = puyo;
+    }
+}
+
+impl Default for Field {
+    fn default() -> Self {
+        Self::new(6, 13)
+    }
+}

--- a/puyosim-core/src/lib.rs
+++ b/puyosim-core/src/lib.rs
@@ -1,0 +1,20 @@
+pub mod field;
+pub mod puyo;
+pub mod simulation;
+
+pub use field::Field;
+pub use puyo::Puyo;
+pub use simulation::{simulate_chains, ChainResult};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_field_has_no_chains() {
+        let mut field = Field::default();
+        let result = simulate_chains(&mut field);
+        assert_eq!(result.chains, 0);
+        assert_eq!(result.score, 0);
+    }
+}

--- a/puyosim-core/src/puyo.rs
+++ b/puyosim-core/src/puyo.rs
@@ -1,0 +1,9 @@
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Puyo {
+    Red,
+    Green,
+    Blue,
+    Yellow,
+    Purple,
+    Ojama,
+}

--- a/puyosim-core/src/simulation.rs
+++ b/puyosim-core/src/simulation.rs
@@ -1,0 +1,16 @@
+use crate::field::Field;
+
+/// Result of a chain simulation.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ChainResult {
+    pub chains: u32,
+    pub score: u32,
+}
+
+/// Simulate chains on the given field.
+///
+/// This is currently a placeholder implementation.
+pub fn simulate_chains(_field: &mut Field) -> ChainResult {
+    // TODO: implement chain reaction logic
+    ChainResult { chains: 0, score: 0 }
+}


### PR DESCRIPTION
## Summary
- add workspace `Cargo.toml`
- create `puyosim-core` crate with basic structures for puyo field simulation
- document the new crate path in README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6877106e255483259baca681423585b4